### PR TITLE
Bump mermaid from 8.2.3 to 8.4.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,300 +13,6 @@
 				"@babel/highlight": "^7.0.0"
 			}
 		},
-		"@babel/core": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
-			"integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
-				"@babel/helpers": "^7.5.5",
-				"@babel/parser": "^7.5.5",
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5",
-				"convert-source-map": "^1.1.0",
-				"debug": "^4.1.0",
-				"json5": "^2.1.0",
-				"lodash": "^4.17.13",
-				"resolve": "^1.3.2",
-				"semver": "^5.4.1",
-				"source-map": "^0.5.0"
-			},
-			"dependencies": {
-				"@babel/parser": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-					"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
-					"dev": true
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"json5": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
-			}
-		},
-		"@babel/generator": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-			"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.5.5",
-				"jsesc": "^2.5.1",
-				"lodash": "^4.17.13",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
-			}
-		},
-		"@babel/helper-annotate-as-pure": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
-			"integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
-			"integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-explode-assignable-expression": "^7.1.0",
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@babel/helper-builder-react-jsx": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
-			"integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.3.0",
-				"esutils": "^2.0.0"
-			}
-		},
-		"@babel/helper-call-delegate": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
-			"integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-hoist-variables": "^7.4.4",
-				"@babel/traverse": "^7.4.4",
-				"@babel/types": "^7.4.4"
-			}
-		},
-		"@babel/helper-create-class-features-plugin": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.5.5.tgz",
-			"integrity": "sha512-ZsxkyYiRA7Bg+ZTRpPvB6AbOFKTFFK4LrvTet8lInm0V468MWCaSYJE+I7v2z2r8KNLtYiV+K5kTCnR7dvyZjg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-member-expression-to-functions": "^7.5.5",
-				"@babel/helper-optimise-call-expression": "^7.0.0",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.5.5",
-				"@babel/helper-split-export-declaration": "^7.4.4"
-			}
-		},
-		"@babel/helper-define-map": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
-			"integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/types": "^7.5.5",
-				"lodash": "^4.17.13"
-			}
-		},
-		"@babel/helper-explode-assignable-expression": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
-			"integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
-			"dev": true,
-			"requires": {
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@babel/helper-function-name": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-get-function-arity": "^7.0.0",
-				"@babel/template": "^7.1.0",
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@babel/helper-hoist-variables": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
-			"integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.4.4"
-			}
-		},
-		"@babel/helper-member-expression-to-functions": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
-			"integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.5.5"
-			}
-		},
-		"@babel/helper-module-imports": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
-			"integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@babel/helper-module-transforms": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
-			"integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"@babel/helper-simple-access": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.4.4",
-				"@babel/template": "^7.4.4",
-				"@babel/types": "^7.5.5",
-				"lodash": "^4.17.13"
-			}
-		},
-		"@babel/helper-optimise-call-expression": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
-			"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@babel/helper-plugin-utils": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
-			"dev": true
-		},
-		"@babel/helper-regex": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
-			"integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.13"
-			}
-		},
-		"@babel/helper-remap-async-to-generator": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
-			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-wrap-function": "^7.1.0",
-				"@babel/template": "^7.1.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@babel/helper-replace-supers": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
-			"integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.5.5",
-				"@babel/helper-optimise-call-expression": "^7.0.0",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5"
-			}
-		},
-		"@babel/helper-simple-access": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
-			"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
-			"dev": true,
-			"requires": {
-				"@babel/template": "^7.1.0",
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@babel/helper-split-export-declaration": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-			"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.4.4"
-			}
-		},
-		"@babel/helper-wrap-function": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
-			"integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/template": "^7.1.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.2.0"
-			}
-		},
-		"@babel/helpers": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
-			"integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
-			"dev": true,
-			"requires": {
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5"
-			}
-		},
 		"@babel/highlight": {
 			"version": "7.5.0",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
@@ -316,895 +22,6 @@
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
 				"js-tokens": "^4.0.0"
-			}
-		},
-		"@babel/parser": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
-			"integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w==",
-			"dev": true
-		},
-		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
-			"integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.1.0",
-				"@babel/plugin-syntax-async-generators": "^7.2.0"
-			}
-		},
-		"@babel/plugin-proposal-class-properties": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz",
-			"integrity": "sha512-AF79FsnWFxjlaosgdi421vmYG6/jg79bVD0dpD44QdgobzHKuLZ6S3vl8la9qIeSwGi8i1fS0O1mfuDAAdo1/A==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.5.5",
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-proposal-decorators": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.4.tgz",
-			"integrity": "sha512-z7MpQz3XC/iQJWXH9y+MaWcLPNSMY9RQSthrLzak8R8hCj0fuyNk+Dzi9kfNe/JxxlWQ2g7wkABbgWjW36MTcw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.4.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-decorators": "^7.2.0"
-			}
-		},
-		"@babel/plugin-proposal-do-expressions": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-do-expressions/-/plugin-proposal-do-expressions-7.5.0.tgz",
-			"integrity": "sha512-xe0QQrhm+DGj6H23a6XtwkJNimy1fo71O/YVBfrfvfSl0fsq9T9dfoQBIY4QceEIdUo7u9s7OPEdsWEuizfGeg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-do-expressions": "^7.2.0"
-			}
-		},
-		"@babel/plugin-proposal-dynamic-import": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
-			"integrity": "sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-dynamic-import": "^7.2.0"
-			}
-		},
-		"@babel/plugin-proposal-export-default-from": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.5.2.tgz",
-			"integrity": "sha512-wr9Itk05L1/wyyZKVEmXWCdcsp/e185WUNl6AfYZeEKYaUPPvHXRDqO5K1VH7/UamYqGJowFRuCv30aDYZawsg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-export-default-from": "^7.2.0"
-			}
-		},
-		"@babel/plugin-proposal-export-namespace-from": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.5.2.tgz",
-			"integrity": "sha512-TKUdOL07anjZEbR1iSxb5WFh810KyObdd29XLFLGo1IDsSuGrjH3ouWSbAxHNmrVKzr9X71UYl2dQ7oGGcRp0g==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-export-namespace-from": "^7.2.0"
-			}
-		},
-		"@babel/plugin-proposal-function-bind": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-function-bind/-/plugin-proposal-function-bind-7.2.0.tgz",
-			"integrity": "sha512-qOFJ/eX1Is78sywwTxDcsntLOdb5ZlHVVqUz5xznq8ldAfOVIyZzp1JE2rzHnaksZIhrqMrwIpQL/qcEprnVbw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-function-bind": "^7.2.0"
-			}
-		},
-		"@babel/plugin-proposal-function-sent": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-function-sent/-/plugin-proposal-function-sent-7.5.0.tgz",
-			"integrity": "sha512-JXdfiQpKoC6UgQliZkp3NX7K3MVec1o1nfTWiCCIORE5ag/QZXhL0aSD8/Y2K+hIHonSTxuJF9rh9zsB6hBi2A==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-wrap-function": "^7.2.0",
-				"@babel/plugin-syntax-function-sent": "^7.2.0"
-			}
-		},
-		"@babel/plugin-proposal-json-strings": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
-			"integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-json-strings": "^7.2.0"
-			}
-		},
-		"@babel/plugin-proposal-logical-assignment-operators": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.2.0.tgz",
-			"integrity": "sha512-0w797xwdPXKk0m3Js74hDi0mCTZplIu93MOSfb1ZLd/XFe3abWypx1QknVk0J+ohnsjYpvjH4Gwfo2i3RicB6Q==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-logical-assignment-operators": "^7.2.0"
-			}
-		},
-		"@babel/plugin-proposal-nullish-coalescing-operator": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.4.4.tgz",
-			"integrity": "sha512-Amph7Epui1Dh/xxUxS2+K22/MUi6+6JVTvy3P58tja3B6yKTSjwwx0/d83rF7551D6PVSSoplQb8GCwqec7HRw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.2.0"
-			}
-		},
-		"@babel/plugin-proposal-numeric-separator": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.2.0.tgz",
-			"integrity": "sha512-DohMOGDrZiMKS7LthjUZNNcWl8TAf5BZDwZAH4wpm55FuJTHgfqPGdibg7rZDmont/8Yg0zA03IgT6XLeP+4sg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-numeric-separator": "^7.2.0"
-			}
-		},
-		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
-			"integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
-			}
-		},
-		"@babel/plugin-proposal-optional-catch-binding": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
-			"integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
-			}
-		},
-		"@babel/plugin-proposal-optional-chaining": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.2.0.tgz",
-			"integrity": "sha512-ea3Q6edZC/55wEBVZAEz42v528VulyO0eir+7uky/sT4XRcdkWJcFi1aPtitTlwUzGnECWJNExWww1SStt+yWw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-optional-chaining": "^7.2.0"
-			}
-		},
-		"@babel/plugin-proposal-pipeline-operator": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-pipeline-operator/-/plugin-proposal-pipeline-operator-7.5.0.tgz",
-			"integrity": "sha512-HFYuu/yGnkn69ligXxU0ohOVvQDsMNOUJs/c4PYLUVS6ntCYOyGmRQQaSYJARJ9rvc7/ulZKIzxd4wk91hN63A==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-pipeline-operator": "^7.5.0"
-			}
-		},
-		"@babel/plugin-proposal-throw-expressions": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-throw-expressions/-/plugin-proposal-throw-expressions-7.2.0.tgz",
-			"integrity": "sha512-adsydM8DQF4i5DLNO4ySAU5VtHTPewOtNBV3u7F4lNMPADFF9bWQ+iDtUUe8+033cYCUz+bFlQdXQJmJOwoLpw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-throw-expressions": "^7.2.0"
-			}
-		},
-		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
-			"integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
-			}
-		},
-		"@babel/plugin-syntax-async-generators": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
-			"integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-decorators": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz",
-			"integrity": "sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-do-expressions": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-do-expressions/-/plugin-syntax-do-expressions-7.2.0.tgz",
-			"integrity": "sha512-/u4rJ+XEmZkIhspVuKRS+7WLvm7Dky9j9TvGK5IgId8B3FKir9MG+nQxDZ9xLn10QMBvW58dZ6ABe2juSmARjg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-dynamic-import": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
-			"integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-export-default-from": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.2.0.tgz",
-			"integrity": "sha512-c7nqUnNST97BWPtoe+Ssi+fJukc9P9/JMZ71IOMNQWza2E+Psrd46N6AEvtw6pqK+gt7ChjXyrw4SPDO79f3Lw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-export-namespace-from": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.2.0.tgz",
-			"integrity": "sha512-1zGA3UNch6A+A11nIzBVEaE3DDJbjfB+eLIcf0GGOh/BJr/8NxL3546MGhV/r0RhH4xADFIEso39TKCfEMlsGA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-flow": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz",
-			"integrity": "sha512-r6YMuZDWLtLlu0kqIim5o/3TNRAlWb073HwT3e2nKf9I8IIvOggPrnILYPsrrKilmn/mYEMCf/Z07w3yQJF6dg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-function-bind": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-function-bind/-/plugin-syntax-function-bind-7.2.0.tgz",
-			"integrity": "sha512-/WzU1lLU2l0wDfB42Wkg6tahrmtBbiD8C4H6EGSX0M4GAjzN6JiOpq/Uh8G6GSoR6lPMvhjM0MNiV6znj6y/zg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-function-sent": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-function-sent/-/plugin-syntax-function-sent-7.2.0.tgz",
-			"integrity": "sha512-2MOVuJ6IMAifp2cf0RFkHQaOvHpbBYyWCvgtF/WVqXhTd7Bgtov8iXVCadLXp2FN1BrI2EFl+JXuwXy0qr3KoQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-import-meta": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.2.0.tgz",
-			"integrity": "sha512-Hq6kFSZD7+PHkmBN8bCpHR6J8QEoCuEV/B38AIQscYjgMZkGlXB7cHNFzP5jR4RCh5545yP1ujHdmO7hAgKtBA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-json-strings": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
-			"integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-jsx": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
-			"integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-logical-assignment-operators": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.2.0.tgz",
-			"integrity": "sha512-l/NKSlrnvd73/EL540t9hZhcSo4TULBrIPs9Palju8Oc/A8DXDO+xQf04whfeuZLpi8AuIvCAdpKmmubLN4EfQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-nullish-coalescing-operator": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.2.0.tgz",
-			"integrity": "sha512-lRCEaKE+LTxDQtgbYajI04ddt6WW0WJq57xqkAZ+s11h4YgfRHhVA/Y2VhfPzzFD4qeLHWg32DMp9HooY4Kqlg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-numeric-separator": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.2.0.tgz",
-			"integrity": "sha512-DroeVNkO/BnGpL2R7+ZNZqW+E24aR/4YWxP3Qb15d6lPU8KDzF8HlIUIRCOJRn4X77/oyW4mJY+7FHfY82NLtQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-object-rest-spread": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
-			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-optional-catch-binding": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
-			"integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-optional-chaining": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.2.0.tgz",
-			"integrity": "sha512-HtGCtvp5Uq/jH/WNUPkK6b7rufnCPLLlDAFN7cmACoIjaOOiXxUt3SswU5loHqrhtqTsa/WoLQ1OQ1AGuZqaWA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-pipeline-operator": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-pipeline-operator/-/plugin-syntax-pipeline-operator-7.5.0.tgz",
-			"integrity": "sha512-5FVxPiMTMXWk4R7Kq9pt272nDu8VImJdaIzvXFSTcXFbgKWWaOdbic12TvUvl6cK+AE5EgnhwvxuWik4ZYYdzg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-syntax-throw-expressions": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-throw-expressions/-/plugin-syntax-throw-expressions-7.2.0.tgz",
-			"integrity": "sha512-ngwynuqu1Rx0JUS9zxSDuPgW1K8TyVZCi2hHehrL4vyjqE7RGoNHWlZsS7KQT2vw9Yjk4YLa0+KldBXTRdPLRg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-arrow-functions": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
-			"integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
-			"integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.1.0"
-			}
-		},
-		"@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
-			"integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-block-scoping": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz",
-			"integrity": "sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"lodash": "^4.17.13"
-			}
-		},
-		"@babel/plugin-transform-classes": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
-			"integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-define-map": "^7.5.5",
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-optimise-call-expression": "^7.0.0",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.5.5",
-				"@babel/helper-split-export-declaration": "^7.4.4",
-				"globals": "^11.1.0"
-			}
-		},
-		"@babel/plugin-transform-computed-properties": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
-			"integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-destructuring": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
-			"integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
-			"integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
-			}
-		},
-		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
-			"integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
-			"integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-flow-strip-types": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.4.tgz",
-			"integrity": "sha512-WyVedfeEIILYEaWGAUWzVNyqG4sfsNooMhXWsu/YzOvVGcsnPb5PguysjJqI3t3qiaYj0BR8T2f5njdjTGe44Q==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-flow": "^7.2.0"
-			}
-		},
-		"@babel/plugin-transform-for-of": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
-			"integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-function-name": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
-			"integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-literals": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
-			"integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-member-expression-literals": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
-			"integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-modules-amd": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
-			"integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-transforms": "^7.1.0",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"babel-plugin-dynamic-import-node": "^2.3.0"
-			}
-		},
-		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
-			"integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-transforms": "^7.4.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-simple-access": "^7.1.0",
-				"babel-plugin-dynamic-import-node": "^2.3.0"
-			}
-		},
-		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
-			"integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-hoist-variables": "^7.4.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"babel-plugin-dynamic-import-node": "^2.3.0"
-			}
-		},
-		"@babel/plugin-transform-modules-umd": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
-			"integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-transforms": "^7.1.0",
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
-			"integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
-			"dev": true,
-			"requires": {
-				"regexp-tree": "^0.1.6"
-			}
-		},
-		"@babel/plugin-transform-new-target": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
-			"integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-object-super": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
-			"integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.5.5"
-			}
-		},
-		"@babel/plugin-transform-parameters": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
-			"integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-call-delegate": "^7.4.4",
-				"@babel/helper-get-function-arity": "^7.0.0",
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-property-literals": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
-			"integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-react-display-name": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
-			"integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-react-jsx": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
-			"integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-builder-react-jsx": "^7.3.0",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-jsx": "^7.2.0"
-			}
-		},
-		"@babel/plugin-transform-react-jsx-self": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
-			"integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-jsx": "^7.2.0"
-			}
-		},
-		"@babel/plugin-transform-react-jsx-source": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.5.0.tgz",
-			"integrity": "sha512-58Q+Jsy4IDCZx7kqEZuSDdam/1oW8OdDX8f+Loo6xyxdfg1yF0GE2XNJQSTZCaMol93+FBzpWiPEwtbMloAcPg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-jsx": "^7.2.0"
-			}
-		},
-		"@babel/plugin-transform-regenerator": {
-			"version": "7.4.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
-			"integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
-			"dev": true,
-			"requires": {
-				"regenerator-transform": "^0.14.0"
-			}
-		},
-		"@babel/plugin-transform-reserved-words": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
-			"integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
-			"integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-spread": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
-			"integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-sticky-regex": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
-			"integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-template-literals": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
-			"integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
-			"integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
-			}
-		},
-		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
-			"integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
-			}
-		},
-		"@babel/preset-env": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.5.5.tgz",
-			"integrity": "sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-				"@babel/plugin-proposal-dynamic-import": "^7.5.0",
-				"@babel/plugin-proposal-json-strings": "^7.2.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.5.5",
-				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
-				"@babel/plugin-syntax-async-generators": "^7.2.0",
-				"@babel/plugin-syntax-dynamic-import": "^7.2.0",
-				"@babel/plugin-syntax-json-strings": "^7.2.0",
-				"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-transform-arrow-functions": "^7.2.0",
-				"@babel/plugin-transform-async-to-generator": "^7.5.0",
-				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-				"@babel/plugin-transform-block-scoping": "^7.5.5",
-				"@babel/plugin-transform-classes": "^7.5.5",
-				"@babel/plugin-transform-computed-properties": "^7.2.0",
-				"@babel/plugin-transform-destructuring": "^7.5.0",
-				"@babel/plugin-transform-dotall-regex": "^7.4.4",
-				"@babel/plugin-transform-duplicate-keys": "^7.5.0",
-				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-				"@babel/plugin-transform-for-of": "^7.4.4",
-				"@babel/plugin-transform-function-name": "^7.4.4",
-				"@babel/plugin-transform-literals": "^7.2.0",
-				"@babel/plugin-transform-member-expression-literals": "^7.2.0",
-				"@babel/plugin-transform-modules-amd": "^7.5.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.5.0",
-				"@babel/plugin-transform-modules-systemjs": "^7.5.0",
-				"@babel/plugin-transform-modules-umd": "^7.2.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
-				"@babel/plugin-transform-new-target": "^7.4.4",
-				"@babel/plugin-transform-object-super": "^7.5.5",
-				"@babel/plugin-transform-parameters": "^7.4.4",
-				"@babel/plugin-transform-property-literals": "^7.2.0",
-				"@babel/plugin-transform-regenerator": "^7.4.5",
-				"@babel/plugin-transform-reserved-words": "^7.2.0",
-				"@babel/plugin-transform-shorthand-properties": "^7.2.0",
-				"@babel/plugin-transform-spread": "^7.2.0",
-				"@babel/plugin-transform-sticky-regex": "^7.2.0",
-				"@babel/plugin-transform-template-literals": "^7.4.4",
-				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-				"@babel/plugin-transform-unicode-regex": "^7.4.4",
-				"@babel/types": "^7.5.5",
-				"browserslist": "^4.6.0",
-				"core-js-compat": "^3.1.1",
-				"invariant": "^2.2.2",
-				"js-levenshtein": "^1.1.3",
-				"semver": "^5.5.0"
-			}
-		},
-		"@babel/preset-flow": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.0.0.tgz",
-			"integrity": "sha512-bJOHrYOPqJZCkPVbG1Lot2r5OSsB+iUOaxiHdlOeB1yPWS6evswVHwvkDLZ54WTaTRIk89ds0iHmGZSnxlPejQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-transform-flow-strip-types": "^7.0.0"
-			}
-		},
-		"@babel/preset-react": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
-			"integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-transform-react-display-name": "^7.0.0",
-				"@babel/plugin-transform-react-jsx": "^7.0.0",
-				"@babel/plugin-transform-react-jsx-self": "^7.0.0",
-				"@babel/plugin-transform-react-jsx-source": "^7.0.0"
-			}
-		},
-		"@babel/preset-stage-0": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-stage-0/-/preset-stage-0-7.0.0.tgz",
-			"integrity": "sha512-FBMd0IiARPtH5aaOFUVki6evHiJQiY0pFy7fizyRF7dtwc+el3nwpzvhb9qBNzceG1OIJModG1xpE0DDFjPXwA==",
-			"dev": true
-		},
-		"@babel/template": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-			"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.4.4",
-				"@babel/types": "^7.4.4"
-			},
-			"dependencies": {
-				"@babel/parser": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-					"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
-					"dev": true
-				}
-			}
-		},
-		"@babel/traverse": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-			"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.4.4",
-				"@babel/parser": "^7.5.5",
-				"@babel/types": "^7.5.5",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.13"
-			},
-			"dependencies": {
-				"@babel/parser": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-					"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
-					"dev": true
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
-			}
-		},
-		"@babel/types": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-			"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
-			"dev": true,
-			"requires": {
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.13",
-				"to-fast-properties": "^2.0.0"
 			}
 		},
 		"@braintree/sanitize-url": {
@@ -1261,12 +78,6 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
 			"integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
-			"dev": true
-		},
-		"@types/unist": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
 			"dev": true
 		},
 		"@types/vscode": {
@@ -1463,16 +274,6 @@
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true
 		},
-		"JSONStream": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-			"dev": true,
-			"requires": {
-				"jsonparse": "^1.2.0",
-				"through": ">=2.2.7 <3"
-			}
-		},
 		"abcjs": {
 			"version": "5.8.0",
 			"resolved": "https://registry.npmjs.org/abcjs/-/abcjs-5.8.0.tgz",
@@ -1527,21 +328,6 @@
 			"integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
 			"dev": true
 		},
-		"ansi-gray": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-			"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-			"dev": true,
-			"requires": {
-				"ansi-wrap": "0.1.0"
-			}
-		},
-		"ansi-html": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
-			"dev": true
-		},
 		"ansi-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -1556,12 +342,6 @@
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
-		},
-		"ansi-wrap": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-			"dev": true
 		},
 		"anymatch": {
 			"version": "2.0.0",
@@ -1582,15 +362,6 @@
 						"remove-trailing-separator": "^1.0.1"
 					}
 				}
-			}
-		},
-		"append-buffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
-			"integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
-			"dev": true,
-			"requires": {
-				"buffer-equal": "^1.0.0"
 			}
 		},
 		"aproba": {
@@ -1688,27 +459,6 @@
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
 		},
-		"babel-plugin-dynamic-import-node": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
-			"integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
-			"dev": true,
-			"requires": {
-				"object.assign": "^4.1.0"
-			}
-		},
-		"babelify": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
-			"integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==",
-			"dev": true
-		},
-		"bail": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
-			"integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==",
-			"dev": true
-		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1800,18 +550,6 @@
 			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
 			"dev": true
 		},
-		"body": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
-			"integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
-			"dev": true,
-			"requires": {
-				"continuable-cache": "^0.3.1",
-				"error": "^7.0.0",
-				"raw-body": "~1.1.0",
-				"safe-json-parse": "~1.0.1"
-			}
-		},
 		"bootstrap3": {
 			"version": "3.3.5",
 			"resolved": "https://registry.npmjs.org/bootstrap3/-/bootstrap3-3.3.5.tgz",
@@ -1861,23 +599,6 @@
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
 			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
 			"dev": true
-		},
-		"browser-resolve": {
-			"version": "1.11.3",
-			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-			"dev": true,
-			"requires": {
-				"resolve": "1.1.7"
-			},
-			"dependencies": {
-				"resolve": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-					"dev": true
-				}
-			}
 		},
 		"browser-stdout": {
 			"version": "1.3.1",
@@ -1956,17 +677,6 @@
 				"pako": "~1.0.5"
 			}
 		},
-		"browserslist": {
-			"version": "4.6.6",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
-			"integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
-			"dev": true,
-			"requires": {
-				"caniuse-lite": "^1.0.30000984",
-				"electron-to-chromium": "^1.3.191",
-				"node-releases": "^1.1.25"
-			}
-		},
 		"buffer": {
 			"version": "4.9.1",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -1978,22 +688,10 @@
 				"isarray": "^1.0.0"
 			}
 		},
-		"buffer-equal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-			"integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
-			"dev": true
-		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
-		},
-		"buffer-shims": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-			"integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
 			"dev": true
 		},
 		"buffer-xor": {
@@ -2012,12 +710,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
 			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
-			"dev": true
-		},
-		"bytes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
-			"integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
 			"dev": true
 		},
 		"cacache": {
@@ -2059,12 +751,6 @@
 				"unset-value": "^1.0.0"
 			}
 		},
-		"cached-path-relative": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
-			"integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
-			"dev": true
-		},
 		"camel-case": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
@@ -2079,18 +765,6 @@
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-			"dev": true
-		},
-		"caniuse-lite": {
-			"version": "1.0.30000985",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000985.tgz",
-			"integrity": "sha512-1ngiwkgqAYPG0JSSUp3PUDGPKKY59EK7NrGGX+VOxaKCNzRbNc7uXMny+c3VJfZxtoK3wSImTvG9T9sXiTw2+w==",
-			"dev": true
-		},
-		"ccount": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
-			"integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
 			"dev": true
 		},
 		"chalk": {
@@ -2114,30 +788,6 @@
 					}
 				}
 			}
-		},
-		"character-entities": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
-			"integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w==",
-			"dev": true
-		},
-		"character-entities-html4": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.3.tgz",
-			"integrity": "sha512-SwnyZ7jQBCRHELk9zf2CN5AnGEc2nA+uKMZLHvcqhpPprjkYhiLn0DywMHgN5ttFZuITMATbh68M6VIVKwJbcg==",
-			"dev": true
-		},
-		"character-entities-legacy": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
-			"integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww==",
-			"dev": true
-		},
-		"character-reference-invalid": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
-			"integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg==",
-			"dev": true
 		},
 		"chokidar": {
 			"version": "2.1.6",
@@ -2208,9 +858,9 @@
 			}
 		},
 		"clean-css": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
-			"integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+			"integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
 			"dev": true,
 			"requires": {
 				"source-map": "~0.6.0"
@@ -2247,45 +897,10 @@
 				"wrap-ansi": "^2.0.0"
 			}
 		},
-		"clone": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-			"dev": true
-		},
-		"clone-buffer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-			"dev": true
-		},
-		"clone-stats": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-			"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-			"dev": true
-		},
-		"cloneable-readable": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
-			"integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"process-nextick-args": "^2.0.0",
-				"readable-stream": "^2.3.5"
-			}
-		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
-		},
-		"collapse-white-space": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
-			"integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ==",
 			"dev": true
 		},
 		"collection-visit": {
@@ -2311,18 +926,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
-		},
-		"color-support": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-			"dev": true
-		},
-		"comma-separated-tokens": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.7.tgz",
-			"integrity": "sha512-Jrx3xsP4pPv4AwJUDWY9wOXGtwPXARej6Xd99h4TUGotmf8APuquKMpK+dnD3UgyxK7OEWaisjZz+3b5jtL6xQ==",
 			"dev": true
 		},
 		"commander": {
@@ -2376,21 +979,6 @@
 			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
 			"dev": true
 		},
-		"continuable-cache": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
-			"integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
-			"dev": true
-		},
-		"convert-source-map": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "~5.1.1"
-			}
-		},
 		"copy-concurrently": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -2409,31 +997,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-			"dev": true
-		},
-		"core-js-compat": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
-			"integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
-			"dev": true,
-			"requires": {
-				"browserslist": "^4.6.2",
-				"core-js-pure": "3.1.4",
-				"semver": "^6.1.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
-			}
-		},
-		"core-js-pure": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
-			"integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -2511,6 +1074,15 @@
 				"randomfill": "^1.0.3"
 			}
 		},
+		"crypto-random-string": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-3.2.0.tgz",
+			"integrity": "sha512-8vPu5bsKaq2uKRy3OL7h1Oo7RayAWB8sYexLKAqvCXVib8SxgbmoF1IN4QMKjBv8uI8mp5gPPMbiRah25GMrVQ==",
+			"dev": true,
+			"requires": {
+				"type-fest": "^0.8.1"
+			}
+		},
 		"css-b64-images": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/css-b64-images/-/css-b64-images-0.2.5.tgz",
@@ -2562,9 +1134,9 @@
 			"dev": true
 		},
 		"d3": {
-			"version": "5.9.7",
-			"resolved": "https://registry.npmjs.org/d3/-/d3-5.9.7.tgz",
-			"integrity": "sha512-jENytrmdXtGPw7HuSK2S4gxRM1eUGjKvWQkQ6ct4yK+DB8SG3VcnVrwesfnsv8rIcxMUg18TafT4Q8mOZUMP4Q==",
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/d3/-/d3-5.15.0.tgz",
+			"integrity": "sha512-C+E80SL2nLLtmykZ6klwYj5rPqB5nlfN5LdWEAVdWPppqTD8taoJi2PxLZjPeYT8FFRR2yucXq+kBlOnnvZeLg==",
 			"dev": true,
 			"requires": {
 				"d3-array": "1",
@@ -2613,9 +1185,9 @@
 			"dev": true
 		},
 		"d3-brush": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.0.6.tgz",
-			"integrity": "sha512-lGSiF5SoSqO5/mYGD5FAeGKKS62JdA1EV7HPrU2b5rTX4qEJJtpjaGLJngjnkewQy7UnGstnFd3168wpf5z76w==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.1.5.tgz",
+			"integrity": "sha512-rEaJ5gHlgLxXugWjIkolTA0OyMvw8UWU1imYXy1v642XyyswmI1ybKOv05Ft+ewq+TFmdliD3VuK0pRp1VT/5A==",
 			"dev": true,
 			"requires": {
 				"d3-dispatch": "1",
@@ -2642,9 +1214,9 @@
 			"dev": true
 		},
 		"d3-color": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.2.8.tgz",
-			"integrity": "sha512-yeANXzP37PHk0DbSTMNPhnJD+Nn4G//O5E825bR6fAfHH43hobSBpgB9G9oWVl9+XgUaQ4yCnsX1H+l8DoaL9A==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.0.tgz",
+			"integrity": "sha512-TzNPeJy2+iEepfiL92LAAB7fvnp/dV2YwANPVHdDWmYMm23qIJBYww3qT8I8C1wXrmrg4UWs7BKc2tKIgyjzHg==",
 			"dev": true
 		},
 		"d3-contour": {
@@ -2657,15 +1229,15 @@
 			}
 		},
 		"d3-dispatch": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.5.tgz",
-			"integrity": "sha512-vwKx+lAqB1UuCeklr6Jh1bvC4SZgbSqbkGBLClItFBIYH4vqDJCA7qfoy14lXmJdnBOdxndAMxjCbImJYW7e6g==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+			"integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
 			"dev": true
 		},
 		"d3-drag": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.3.tgz",
-			"integrity": "sha512-8S3HWCAg+ilzjJsNtWW1Mutl74Nmzhb9yU6igspilaJzeZVFktmY6oO9xOh5TDk+BM2KrNFjttZNoJJmDnkjkg==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz",
+			"integrity": "sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==",
 			"dev": true,
 			"requires": {
 				"d3-dispatch": "1",
@@ -2673,9 +1245,9 @@
 			}
 		},
 		"d3-dsv": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.1.1.tgz",
-			"integrity": "sha512-1EH1oRGSkeDUlDRbhsFytAXU6cAmXFzc52YUe6MRlPClmWb85MP1J5x+YJRzya4ynZWnbELdSAvATFW/MbxaXw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.2.0.tgz",
+			"integrity": "sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==",
 			"dev": true,
 			"requires": {
 				"commander": "2",
@@ -2684,9 +1256,9 @@
 			}
 		},
 		"d3-ease": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.5.tgz",
-			"integrity": "sha512-Ct1O//ly5y5lFM9YTdu+ygq7LleSgSE4oj7vUt9tPLHUi8VCV7QoizGpdWRWAwCO9LdYzIrQDg97+hGVdsSGPQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.6.tgz",
+			"integrity": "sha512-SZ/lVU7LRXafqp7XtIcBdxnWl8yyLpgOmzAk0mWBI9gXNzLDx5ybZgnRbH9dN/yY5tzVBqCQ9avltSnqVwessQ==",
 			"dev": true
 		},
 		"d3-fetch": {
@@ -2711,51 +1283,51 @@
 			}
 		},
 		"d3-format": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.3.2.tgz",
-			"integrity": "sha512-Z18Dprj96ExragQ0DeGi+SYPQ7pPfRMtUXtsg/ChVIKNBCzjO8XYJvRTC1usblx52lqge56V5ect+frYTQc8WQ==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.3.tgz",
+			"integrity": "sha512-mm/nE2Y9HgGyjP+rKIekeITVgBtX97o1nrvHCWX8F/yBYyevUTvu9vb5pUnKwrcSw7o7GuwMOWjS9gFDs4O+uQ==",
 			"dev": true
 		},
 		"d3-geo": {
-			"version": "1.11.6",
-			"resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.11.6.tgz",
-			"integrity": "sha512-z0J8InXR9e9wcgNtmVnPTj0TU8nhYT6lD/ak9may2PdKqXIeHUr8UbFLoCtrPYNsjv6YaLvSDQVl578k6nm7GA==",
+			"version": "1.11.9",
+			"resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.11.9.tgz",
+			"integrity": "sha512-9edcH6J3s/Aa3KJITWqFJbyB/8q3mMlA9Fi7z6yy+FAYMnRaxmC7jBhUnsINxVWD14GmqX3DK8uk7nV6/Ekt4A==",
 			"dev": true,
 			"requires": {
 				"d3-array": "1"
 			}
 		},
 		"d3-hierarchy": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
-			"integrity": "sha512-L+GHMSZNwTpiq4rt9GEsNcpLa4M96lXMR8M/nMG9p5hBE0jy6C+3hWtyZMenPQdwla249iJy7Nx0uKt3n+u9+w==",
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
+			"integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==",
 			"dev": true
 		},
 		"d3-interpolate": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.3.2.tgz",
-			"integrity": "sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+			"integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
 			"dev": true,
 			"requires": {
 				"d3-color": "1"
 			}
 		},
 		"d3-path": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.7.tgz",
-			"integrity": "sha512-q0cW1RpvA5c5ma2rch62mX8AYaiLX0+bdaSM2wxSU9tXjU4DNvkx9qiUvjkuWCj3p22UO/hlPivujqMiR9PDzA==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+			"integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
 			"dev": true
 		},
 		"d3-polygon": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.5.tgz",
-			"integrity": "sha512-RHhh1ZUJZfhgoqzWWuRhzQJvO7LavchhitSTHGu9oj6uuLFzYZVeBzaWTQ2qSO6bz2w55RMoOCf0MsLCDB6e0w==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-1.0.6.tgz",
+			"integrity": "sha512-k+RF7WvI08PC8reEoXa/w2nSg5AUMTi+peBD9cmFc+0ixHfbs4QmxxkarVal1IkVkgxVuk9JSHhJURHiyHKAuQ==",
 			"dev": true
 		},
 		"d3-quadtree": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.6.tgz",
-			"integrity": "sha512-NUgeo9G+ENQCQ1LsRr2qJg3MQ4DJvxcDNCiohdJGHt5gRhBW6orIB5m5FJ9kK3HNL8g9F4ERVoBzcEwQBfXWVA==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
+			"integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==",
 			"dev": true
 		},
 		"d3-random": {
@@ -2779,9 +1351,9 @@
 			}
 		},
 		"d3-scale-chromatic": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.3.3.tgz",
-			"integrity": "sha512-BWTipif1CimXcYfT02LKjAyItX5gKiwxuPRgr4xM58JwlLocWbjPLI7aMEjkcoOQXMkYsmNsvv3d2yl/OKuHHw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz",
+			"integrity": "sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==",
 			"dev": true,
 			"requires": {
 				"d3-color": "1",
@@ -2789,45 +1361,45 @@
 			}
 		},
 		"d3-selection": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.0.tgz",
-			"integrity": "sha512-EYVwBxQGEjLCKF2pJ4+yrErskDnz5v403qvAid96cNdCMr8rmCYfY5RGzWz24mdIbxmDf6/4EAH+K9xperD5jg==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.1.tgz",
+			"integrity": "sha512-BTIbRjv/m5rcVTfBs4AMBLKs4x8XaaLkwm28KWu9S2vKNqXkXt2AH2Qf0sdPZHjFxcWg/YL53zcqAz+3g4/7PA==",
 			"dev": true
 		},
 		"d3-shape": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.5.tgz",
-			"integrity": "sha512-VKazVR3phgD+MUCldapHD7P9kcrvPcexeX/PkMJmkUov4JM8IxsSg1DvbYoYich9AtdTsa5nNk2++ImPiDiSxg==",
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+			"integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
 			"dev": true,
 			"requires": {
 				"d3-path": "1"
 			}
 		},
 		"d3-time": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.11.tgz",
-			"integrity": "sha512-Z3wpvhPLW4vEScGeIMUckDW7+3hWKOQfAWg/U7PlWBnQmeKQ00gCUsTtWSYulrKNA7ta8hJ+xXc6MHrMuITwEw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+			"integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==",
 			"dev": true
 		},
 		"d3-time-format": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.3.tgz",
-			"integrity": "sha512-6k0a2rZryzGm5Ihx+aFMuO1GgelgIz+7HhB4PH4OEndD5q2zGn1mDfRdNrulspOfR6JXkb2sThhDK41CSK85QA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.3.tgz",
+			"integrity": "sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==",
 			"dev": true,
 			"requires": {
 				"d3-time": "1"
 			}
 		},
 		"d3-timer": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.9.tgz",
-			"integrity": "sha512-rT34J5HnQUHhcLvhSB9GjCkN0Ddd5Y8nCwDBG2u6wQEeYxT/Lf51fTFFkldeib/sE/J0clIe0pnCfs6g/lRbyg==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+			"integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
 			"dev": true
 		},
 		"d3-transition": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.2.0.tgz",
-			"integrity": "sha512-VJ7cmX/FPIPJYuaL2r1o1EMHLttvoIuZhhuAlRoOxDzogV8iQS6jYulDm3xEU3TqL80IZIhI551/ebmCMrkvhw==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.3.2.tgz",
+			"integrity": "sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==",
 			"dev": true,
 			"requires": {
 				"d3-color": "1",
@@ -2845,9 +1417,9 @@
 			"dev": true
 		},
 		"d3-zoom": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.3.tgz",
-			"integrity": "sha512-xEBSwFx5Z9T3/VrwDkMt+mr0HCzv7XjpGURJ8lWmIC8wxe32L39eWHIasEe/e7Ox8MPU4p1hvH8PKN2olLzIBg==",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.8.3.tgz",
+			"integrity": "sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==",
 			"dev": true,
 			"requires": {
 				"d3-dispatch": "1",
@@ -2857,36 +1429,32 @@
 				"d3-transition": "1"
 			}
 		},
-		"dagre-d3-renderer": {
-			"version": "0.5.8",
-			"resolved": "https://registry.npmjs.org/dagre-d3-renderer/-/dagre-d3-renderer-0.5.8.tgz",
-			"integrity": "sha512-XH2a86isUHRxzIYbjQVEuZtJnWEufb64H5DuXIUmn8esuB40jgLEbUUclulWOW62/ZoXlj2ZDyL8SJ+YRxs+jQ==",
+		"dagre": {
+			"version": "0.8.5",
+			"resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
+			"integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
 			"dev": true,
 			"requires": {
-				"dagre-layout": "^0.8.8",
-				"lodash": "^4.17.5"
+				"graphlib": "^2.1.8",
+				"lodash": "^4.17.15"
 			}
 		},
-		"dagre-layout": {
-			"version": "0.8.8",
-			"resolved": "https://registry.npmjs.org/dagre-layout/-/dagre-layout-0.8.8.tgz",
-			"integrity": "sha512-ZNV15T9za7X+fV8Z07IZquUKugCxm5owoiPPxfEx6OJRD331nkiIaF3vSt0JEY5FkrY0KfRQxcpQ3SpXB7pLPQ==",
+		"dagre-d3": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/dagre-d3/-/dagre-d3-0.6.4.tgz",
+			"integrity": "sha512-e/6jXeCP7/ptlAM48clmX4xTZc5Ek6T6kagS7Oz2HrYSdqcLZFLqpAfh7ldbZRFfxCZVyh61NEPR08UQRVxJzQ==",
 			"dev": true,
 			"requires": {
-				"graphlibrary": "^2.2.0",
-				"lodash": "^4.17.5"
+				"d3": "^5.14",
+				"dagre": "^0.8.5",
+				"graphlib": "^2.1.8",
+				"lodash": "^4.17.15"
 			}
 		},
 		"date-now": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
 			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
-			"dev": true
-		},
-		"de-indent": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-			"integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
 			"dev": true
 		},
 		"debug": {
@@ -2960,12 +1528,6 @@
 				}
 			}
 		},
-		"defined": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-			"dev": true
-		},
 		"delegate": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
@@ -2983,38 +1545,11 @@
 				"minimalistic-assert": "^1.0.0"
 			}
 		},
-		"detab": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/detab/-/detab-2.0.2.tgz",
-			"integrity": "sha512-Q57yPrxScy816TTE1P/uLRXLDKjXhvYTbfxS/e6lPD+YrqghbsMlGB9nQzj/zVtSPaF0DFPSdO916EWO4sQUyQ==",
-			"dev": true,
-			"requires": {
-				"repeat-string": "^1.5.4"
-			}
-		},
 		"detect-file": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
 			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
 			"dev": true
-		},
-		"detective": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-			"integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
-			"dev": true,
-			"requires": {
-				"acorn": "^5.2.1",
-				"defined": "^1.0.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "5.7.3",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-					"dev": true
-				}
-			}
 		},
 		"diff": {
 			"version": "3.5.0",
@@ -3033,152 +1568,11 @@
 				"randombytes": "^2.0.0"
 			}
 		},
-		"doctrine-temporary-fork": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/doctrine-temporary-fork/-/doctrine-temporary-fork-2.1.0.tgz",
-			"integrity": "sha512-nliqOv5NkE4zMON4UA6AMJE6As35afs8aYXATpU4pTUdIKiARZwrJVEP1boA3Rx1ZXHVkwxkhcq4VkqvsuRLsA==",
-			"dev": true,
-			"requires": {
-				"esutils": "^2.0.2"
-			}
-		},
-		"documentation": {
-			"version": "12.0.3",
-			"resolved": "https://registry.npmjs.org/documentation/-/documentation-12.0.3.tgz",
-			"integrity": "sha512-RoqkH+mQ4Vi/nFMxG0BaqPAnjKfsJ9lbLWB8KqoKVAZy+urSpk1K1zBzaFesdDkKeaR3aBgeR3RjtHp8Ut/1Wg==",
-			"dev": true,
-			"requires": {
-				"@babel/core": "^7.1.2",
-				"@babel/generator": "^7.1.3",
-				"@babel/parser": "7.1.3",
-				"@babel/plugin-proposal-class-properties": "^7.1.0",
-				"@babel/plugin-proposal-decorators": "^7.1.2",
-				"@babel/plugin-proposal-do-expressions": "^7.0.0",
-				"@babel/plugin-proposal-export-default-from": "^7.0.0",
-				"@babel/plugin-proposal-export-namespace-from": "^7.0.0",
-				"@babel/plugin-proposal-function-bind": "^7.0.0",
-				"@babel/plugin-proposal-function-sent": "^7.1.0",
-				"@babel/plugin-proposal-json-strings": "^7.0.0",
-				"@babel/plugin-proposal-logical-assignment-operators": "^7.0.0",
-				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
-				"@babel/plugin-proposal-numeric-separator": "^7.0.0",
-				"@babel/plugin-proposal-optional-chaining": "^7.0.0",
-				"@babel/plugin-proposal-pipeline-operator": "^7.0.0",
-				"@babel/plugin-proposal-throw-expressions": "^7.0.0",
-				"@babel/plugin-syntax-dynamic-import": "^7.0.0",
-				"@babel/plugin-syntax-import-meta": "^7.0.0",
-				"@babel/preset-env": "^7.1.0",
-				"@babel/preset-flow": "^7.0.0",
-				"@babel/preset-react": "^7.0.0",
-				"@babel/preset-stage-0": "^7.0.0",
-				"@babel/traverse": "^7.1.4",
-				"@babel/types": "^7.1.3",
-				"ansi-html": "^0.0.7",
-				"babelify": "^10.0.0",
-				"chalk": "^2.3.0",
-				"chokidar": "^2.0.4",
-				"concat-stream": "^1.6.0",
-				"diff": "^4.0.1",
-				"doctrine-temporary-fork": "2.1.0",
-				"get-port": "^4.0.0",
-				"git-url-parse": "^10.0.1",
-				"github-slugger": "1.2.0",
-				"glob": "^7.1.2",
-				"globals-docs": "^2.4.0",
-				"highlight.js": "^9.15.5",
-				"js-yaml": "^3.10.0",
-				"lodash": "^4.17.10",
-				"mdast-util-inject": "^1.1.0",
-				"micromatch": "^3.1.5",
-				"mime": "^2.2.0",
-				"module-deps-sortable": "5.0.0",
-				"parse-filepath": "^1.0.2",
-				"pify": "^4.0.0",
-				"read-pkg-up": "^4.0.0",
-				"remark": "^9.0.0",
-				"remark-html": "^8.0.0",
-				"remark-reference-links": "^4.0.1",
-				"remark-toc": "^5.0.0",
-				"remote-origin-url": "0.4.0",
-				"resolve": "^1.8.1",
-				"stream-array": "^1.1.2",
-				"strip-json-comments": "^2.0.1",
-				"tiny-lr": "^1.1.0",
-				"unist-builder": "^1.0.2",
-				"unist-util-visit": "^1.3.0",
-				"vfile": "^4.0.0",
-				"vfile-reporter": "^6.0.0",
-				"vfile-sort": "^2.1.0",
-				"vinyl": "^2.1.0",
-				"vinyl-fs": "^3.0.2",
-				"vue-template-compiler": "^2.5.16",
-				"yargs": "^12.0.2"
-			},
-			"dependencies": {
-				"diff": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-					"integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
-					"dev": true
-				},
-				"get-caller-file": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-					"dev": true
-				},
-				"require-main-filename": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-					"dev": true
-				},
-				"yargs": {
-					"version": "12.0.5",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-					"dev": true,
-					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^11.1.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "11.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
-			}
-		},
 		"domain-browser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
 			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
 			"dev": true
-		},
-		"duplexer2": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.2"
-			}
 		},
 		"duplexify": {
 			"version": "3.7.1",
@@ -3191,12 +1585,6 @@
 				"readable-stream": "^2.0.0",
 				"stream-shift": "^1.0.0"
 			}
-		},
-		"electron-to-chromium": {
-			"version": "1.3.200",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.200.tgz",
-			"integrity": "sha512-PUurrpyDA74MuAjJRD+79ss5BqJlU3mdArRbuu4wO/dt6jc3Ic/6BDmFJxkdwbfq39cHf/XKm2vW98XSvut9Dg==",
-			"dev": true
 		},
 		"elliptic": {
 			"version": "6.5.0",
@@ -3252,25 +1640,6 @@
 			"dev": true,
 			"requires": {
 				"prr": "~1.0.1"
-			}
-		},
-		"error": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
-			"integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
-			"dev": true,
-			"requires": {
-				"string-template": "~0.2.1",
-				"xtend": "~4.0.0"
-			}
-		},
-		"error-ex": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-			"dev": true,
-			"requires": {
-				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -3463,12 +1832,6 @@
 				"homedir-polyfill": "^1.0.1"
 			}
 		},
-		"extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"dev": true
-		},
 		"extend-shallow": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -3555,18 +1918,6 @@
 				}
 			}
 		},
-		"fancy-log": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
-			"integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
-			"dev": true,
-			"requires": {
-				"ansi-gray": "^0.1.1",
-				"color-support": "^1.1.3",
-				"parse-node-version": "^1.0.0",
-				"time-stamp": "^1.0.0"
-			}
-		},
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -3578,15 +1929,6 @@
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
 			"dev": true
-		},
-		"faye-websocket": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-			"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-			"dev": true,
-			"requires": {
-				"websocket-driver": ">=0.5.1"
-			}
 		},
 		"figgy-pudding": {
 			"version": "3.5.1",
@@ -3700,16 +2042,6 @@
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
-			}
-		},
-		"fs-mkdirp-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
-			"integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.11",
-				"through2": "^2.0.3"
 			}
 		},
 		"fs-write-stream-atomic": {
@@ -4290,12 +2622,6 @@
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
 		},
-		"get-port": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/get-port/-/get-port-4.2.0.tgz",
-			"integrity": "sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==",
-			"dev": true
-		},
 		"get-stream": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -4310,42 +2636,6 @@
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
 			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
 			"dev": true
-		},
-		"git-up": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/git-up/-/git-up-2.1.0.tgz",
-			"integrity": "sha512-MJgwfcSd9qxgDyEYpRU/CDxNpUadrK80JHuEQDG4Urn0m7tpSOgCBrtiSIa9S9KH8Tbuo/TN8SSQmJBvsw1HkA==",
-			"dev": true,
-			"requires": {
-				"is-ssh": "^1.3.0",
-				"parse-url": "^3.0.2"
-			}
-		},
-		"git-url-parse": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-10.1.0.tgz",
-			"integrity": "sha512-goZOORAtFjU1iG+4zZgWq+N7It09PqS3Xsy43ZwhP5unDD0tTSmXTpqULHodMdJXGejm3COwXIhIRT6Z8DYVZQ==",
-			"dev": true,
-			"requires": {
-				"git-up": "^2.0.0"
-			}
-		},
-		"github-slugger": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.2.0.tgz",
-			"integrity": "sha512-wIaa75k1vZhyPm9yWrD08A5Xnx/V+RmzGrpjQuLemGKSb77Qukiaei58Bogrl/LZSADDfPzKJX8jhLs4CRTl7Q==",
-			"dev": true,
-			"requires": {
-				"emoji-regex": ">=6.0.0 <=6.1.1"
-			},
-			"dependencies": {
-				"emoji-regex": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
-					"integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=",
-					"dev": true
-				}
-			}
 		},
 		"glob": {
 			"version": "7.1.4",
@@ -4380,24 +2670,6 @@
 						"is-extglob": "^2.1.0"
 					}
 				}
-			}
-		},
-		"glob-stream": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
-			"integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
-			"dev": true,
-			"requires": {
-				"extend": "^3.0.0",
-				"glob": "^7.1.1",
-				"glob-parent": "^3.1.0",
-				"is-negated-glob": "^1.0.0",
-				"ordered-read-streams": "^1.0.0",
-				"pumpify": "^1.3.5",
-				"readable-stream": "^2.1.5",
-				"remove-trailing-separator": "^1.0.1",
-				"to-absolute-glob": "^2.0.0",
-				"unique-stream": "^2.0.2"
 			}
 		},
 		"global-modules": {
@@ -4435,18 +2707,6 @@
 				"which": "^1.2.14"
 			}
 		},
-		"globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true
-		},
-		"globals-docs": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/globals-docs/-/globals-docs-2.4.0.tgz",
-			"integrity": "sha512-B69mWcqCmT3jNYmSxRxxOXWfzu3Go8NQXPfl2o0qPd1EEFhwW0dFUg9ztTu915zPQzqwIhWAlw6hmfIcCK4kkQ==",
-			"dev": true
-		},
 		"good-listener": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
@@ -4463,13 +2723,13 @@
 			"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
 			"dev": true
 		},
-		"graphlibrary": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/graphlibrary/-/graphlibrary-2.2.0.tgz",
-			"integrity": "sha512-XTcvT55L8u4MBZrM37zXoUxsgxs/7sow7YSygd9CIwfWTVO8RVu7AYXhhCiTuFEf+APKgx6Jk4SuQbYR0vYKmQ==",
+		"graphlib": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+			"integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.5"
+				"lodash": "^4.17.15"
 			}
 		},
 		"growl": {
@@ -4477,26 +2737,6 @@
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
-		},
-		"gulp-print": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/gulp-print/-/gulp-print-5.0.2.tgz",
-			"integrity": "sha512-iIpHMzC/b3gFvVXOfP9Jk94SWGIsDLVNUrxULRleQev+08ug07mh84b1AOlW6QDQdmInQiqDFqJN1UvhU2nXdg==",
-			"dev": true,
-			"requires": {
-				"ansi-colors": "^3.2.4",
-				"fancy-log": "^1.3.3",
-				"map-stream": "0.0.7",
-				"vinyl": "^2.2.0"
-			},
-			"dependencies": {
-				"ansi-colors": {
-					"version": "3.2.4",
-					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
-					"integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
-					"dev": true
-				}
-			}
 		},
 		"has": {
 			"version": "1.0.3",
@@ -4577,53 +2817,6 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
-		"hast-util-is-element": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.3.tgz",
-			"integrity": "sha512-C62CVn7jbjp89yOhhy7vrkSaB7Vk906Gtcw/Ihd+Iufnq+2pwOZjdPmpzpKLWJXPJBMDX3wXg4FqmdOayPcewA==",
-			"dev": true
-		},
-		"hast-util-sanitize": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-1.3.1.tgz",
-			"integrity": "sha512-AIeKHuHx0Wk45nSkGVa2/ujQYTksnDl8gmmKo/mwQi7ag7IBZ8cM3nJ2G86SajbjGP/HRpud6kMkPtcM2i0Tlw==",
-			"dev": true,
-			"requires": {
-				"xtend": "^4.0.1"
-			}
-		},
-		"hast-util-to-html": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-4.0.1.tgz",
-			"integrity": "sha512-2emzwyf0xEsc4TBIPmDJmBttIw8R4SXAJiJZoiRR/s47ODYWgOqNoDbf2SJAbMbfNdFWMiCSOrI3OVnX6Qq2Mg==",
-			"dev": true,
-			"requires": {
-				"ccount": "^1.0.0",
-				"comma-separated-tokens": "^1.0.1",
-				"hast-util-is-element": "^1.0.0",
-				"hast-util-whitespace": "^1.0.0",
-				"html-void-elements": "^1.0.0",
-				"property-information": "^4.0.0",
-				"space-separated-tokens": "^1.0.0",
-				"stringify-entities": "^1.0.1",
-				"unist-util-is": "^2.0.0",
-				"xtend": "^4.0.1"
-			},
-			"dependencies": {
-				"unist-util-is": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.3.tgz",
-					"integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA==",
-					"dev": true
-				}
-			}
-		},
-		"hast-util-whitespace": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.3.tgz",
-			"integrity": "sha512-AlkYiLTTwPOyxZ8axq2/bCwRUPjIPBfrHkXuCR92B38b3lSdU22R5F/Z4DL6a2kxWpekWq1w6Nj48tWat6GeRA==",
-			"dev": true
-		},
 		"he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -4656,12 +2849,6 @@
 				"parse-passwd": "^1.0.0"
 			}
 		},
-		"hosted-git-info": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-			"dev": true
-		},
 		"html-minifier": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
@@ -4676,18 +2863,6 @@
 				"relateurl": "^0.2.7",
 				"uglify-js": "^3.5.1"
 			}
-		},
-		"html-void-elements": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.4.tgz",
-			"integrity": "sha512-yMk3naGPLrfvUV9TdDbuYXngh/TpHbA6TrOw3HL9kS8yhwx7i309BReNg7CbAJXGE+UMJ6je5OqJ7lC63o6YuQ==",
-			"dev": true
-		},
-		"http-parser-js": {
-			"version": "0.4.10",
-			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
-			"integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
-			"dev": true
 		},
 		"http-proxy-agent": {
 			"version": "2.1.0",
@@ -4836,30 +3011,11 @@
 			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
 			"dev": true
 		},
-		"invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.0.0"
-			}
-		},
 		"invert-kv": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
 			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
 			"dev": true
-		},
-		"is-absolute": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-			"integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-			"dev": true,
-			"requires": {
-				"is-relative": "^1.0.0",
-				"is-windows": "^1.0.1"
-			}
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
@@ -4886,34 +3042,6 @@
 					}
 				}
 			}
-		},
-		"is-alphabetical": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
-			"integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==",
-			"dev": true
-		},
-		"is-alphanumeric": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
-			"integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=",
-			"dev": true
-		},
-		"is-alphanumerical": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
-			"integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
-			"dev": true,
-			"requires": {
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0"
-			}
-		},
-		"is-arrayish": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-			"dev": true
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
@@ -4968,12 +3096,6 @@
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
 			"dev": true
 		},
-		"is-decimal": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
-			"integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==",
-			"dev": true
-		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -5019,18 +3141,6 @@
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
-		},
-		"is-hexadecimal": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
-			"integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
-			"dev": true
-		},
-		"is-negated-glob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-			"integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
-			"dev": true
 		},
 		"is-number": {
 			"version": "3.0.0",
@@ -5088,24 +3198,6 @@
 			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
 			"dev": true
 		},
-		"is-relative": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-			"integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-			"dev": true,
-			"requires": {
-				"is-unc-path": "^1.0.0"
-			}
-		},
-		"is-ssh": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
-			"integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
-			"dev": true,
-			"requires": {
-				"protocols": "^1.1.0"
-			}
-		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -5121,43 +3213,10 @@
 				"has-symbols": "^1.0.0"
 			}
 		},
-		"is-unc-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-			"integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-			"dev": true,
-			"requires": {
-				"unc-path-regex": "^0.1.2"
-			}
-		},
-		"is-utf8": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-			"dev": true
-		},
-		"is-valid-glob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-			"integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
-			"dev": true
-		},
-		"is-whitespace-character": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
-			"integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==",
-			"dev": true
-		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"dev": true
-		},
-		"is-word-character": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
-			"integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==",
 			"dev": true
 		},
 		"is-wsl": {
@@ -5188,12 +3247,6 @@
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
 			"integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
-			"dev": true
-		},
-		"js-levenshtein": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-			"integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
 			"dev": true
 		},
 		"js-sequence-diagrams": {
@@ -5232,12 +3285,6 @@
 				"esprima": "^4.0.0"
 			}
 		},
-		"jsesc": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-			"dev": true
-		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -5248,12 +3295,6 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
-		},
-		"json-stable-stringify-without-jsonify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
 		},
 		"json5": {
@@ -5273,12 +3314,6 @@
 				}
 			}
 		},
-		"jsonparse": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-			"dev": true
-		},
 		"katex": {
 			"version": "0.10.2",
 			"resolved": "https://registry.npmjs.org/katex/-/katex-0.10.2.tgz",
@@ -5294,15 +3329,6 @@
 			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 			"dev": true
 		},
-		"lazystream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.5"
-			}
-		},
 		"lcid": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -5310,41 +3336,6 @@
 			"dev": true,
 			"requires": {
 				"invert-kv": "^2.0.0"
-			}
-		},
-		"lead": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
-			"integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
-			"dev": true,
-			"requires": {
-				"flush-write-stream": "^1.0.2"
-			}
-		},
-		"livereload-js": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.4.0.tgz",
-			"integrity": "sha512-XPQH8Z2GDP/Hwz2PCDrh2mth4yFejwA1OZ/81Ti3LgKyhDcEjsSsqFWZojHG0va/duGd+WyosY7eXLDoOyqcPw==",
-			"dev": true
-		},
-		"load-json-file": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^4.0.0",
-				"pify": "^3.0.0",
-				"strip-bom": "^3.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				}
 			}
 		},
 		"loader-runner": {
@@ -5387,21 +3378,6 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1"
-			}
-		},
-		"longest-streak": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz",
-			"integrity": "sha512-9lz5IVdpwsKLMzQi0MQ+oD9EA0mIGcWYP7jXMTZVXP8D42PwuAk+M/HBFYQoxt1G5OR8m7aSIgb1UymfWGBWEw==",
-			"dev": true
-		},
-		"loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
-			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
 		"lower-case": {
@@ -5450,12 +3426,6 @@
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
 			"dev": true
 		},
-		"map-stream": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-			"integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
-			"dev": true
-		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -5464,12 +3434,6 @@
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
-		},
-		"markdown-escapes": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
-			"integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==",
-			"dev": true
 		},
 		"markdown-it-abbr": {
 			"version": "1.0.4",
@@ -5516,12 +3480,6 @@
 			"resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.4.4.tgz",
 			"integrity": "sha512-TAIHTHPwa9+ltKvKPWulm/beozQU41Ab+FIefRaQV1NRnpzwcV9QOe6wXQS5WLivm5Q/nlo0rl6laGkMDZE7Gw=="
 		},
-		"markdown-table": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
-			"integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
-			"dev": true
-		},
 		"md5.js": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -5532,99 +3490,6 @@
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.1.2"
 			}
-		},
-		"mdast-util-compact": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.3.tgz",
-			"integrity": "sha512-nRiU5GpNy62rZppDKbLwhhtw5DXoFMqw9UNZFmlPsNaQCZ//WLjGKUwWMdJrUH+Se7UvtO2gXtAMe0g/N+eI5w==",
-			"dev": true,
-			"requires": {
-				"unist-util-visit": "^1.1.0"
-			}
-		},
-		"mdast-util-definitions": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.4.tgz",
-			"integrity": "sha512-HfUArPog1j4Z78Xlzy9Q4aHLnrF/7fb57cooTHypyGoe2XFNbcx/kWZDoOz+ra8CkUzvg3+VHV434yqEd1DRmA==",
-			"dev": true,
-			"requires": {
-				"unist-util-visit": "^1.0.0"
-			}
-		},
-		"mdast-util-inject": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-inject/-/mdast-util-inject-1.1.0.tgz",
-			"integrity": "sha1-2wa4tYW+lZotzS+H9HK6m3VvNnU=",
-			"dev": true,
-			"requires": {
-				"mdast-util-to-string": "^1.0.0"
-			}
-		},
-		"mdast-util-to-hast": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-3.0.4.tgz",
-			"integrity": "sha512-/eIbly2YmyVgpJNo+bFLLMCI1XgolO/Ffowhf+pHDq3X4/V6FntC9sGQCDLM147eTS+uSXv5dRzJyFn+o0tazA==",
-			"dev": true,
-			"requires": {
-				"collapse-white-space": "^1.0.0",
-				"detab": "^2.0.0",
-				"mdast-util-definitions": "^1.2.0",
-				"mdurl": "^1.0.1",
-				"trim": "0.0.1",
-				"trim-lines": "^1.0.0",
-				"unist-builder": "^1.0.1",
-				"unist-util-generated": "^1.1.0",
-				"unist-util-position": "^3.0.0",
-				"unist-util-visit": "^1.1.0",
-				"xtend": "^4.0.1"
-			}
-		},
-		"mdast-util-to-string": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.0.6.tgz",
-			"integrity": "sha512-868pp48gUPmZIhfKrLbaDneuzGiw3OTDjHc5M1kAepR2CWBJ+HpEsm252K4aXdiP5coVZaJPOqGtVU6Po8xnXg==",
-			"dev": true
-		},
-		"mdast-util-toc": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-toc/-/mdast-util-toc-3.1.0.tgz",
-			"integrity": "sha512-Za0hqL1PqWrvxGtA/3NH9D5nhGAUS9grMM4obEAz5+zsk1RIw/vWUchkaoDLNdrwk05A0CSC5eEXng36/1qE5w==",
-			"dev": true,
-			"requires": {
-				"github-slugger": "^1.2.1",
-				"mdast-util-to-string": "^1.0.5",
-				"unist-util-is": "^2.1.2",
-				"unist-util-visit": "^1.1.0"
-			},
-			"dependencies": {
-				"emoji-regex": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
-					"integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=",
-					"dev": true
-				},
-				"github-slugger": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.2.1.tgz",
-					"integrity": "sha512-SsZUjg/P03KPzQBt7OxJPasGw6NRO5uOgiZ5RGXVud5iSIZ0eNZeNp5rTwCxtavrRUa/A77j8mePVc5lEvk0KQ==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": ">=6.0.0 <=6.1.1"
-					}
-				},
-				"unist-util-is": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.3.tgz",
-					"integrity": "sha512-4WbQX2iwfr/+PfM4U3zd2VNXY+dWtZsN1fLnWEi2QQXA4qyDYAZcDMfXUX0Cu6XZUHHAO9q4nyxxLT4Awk1qUA==",
-					"dev": true
-				}
-			}
-		},
-		"mdurl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
-			"dev": true
 		},
 		"mem": {
 			"version": "4.3.0",
@@ -5648,18 +3513,17 @@
 			}
 		},
 		"mermaid": {
-			"version": "8.2.3",
-			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.2.3.tgz",
-			"integrity": "sha512-G2p9BAAEeTtogPs4YXM8KyX+TsZULlgk0tGvmBPfBZ5j3YCPxgAxG9ZzleiYNItF7M1hGkE485BDLN8DbfR+/Q==",
+			"version": "8.4.8",
+			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-8.4.8.tgz",
+			"integrity": "sha512-sumTNBFwMX7oMQgogdr3NhgTeQOiwcEsm23rQ4KHGW7tpmvMwER1S+1gjCSSnqlmM/zw7Ga7oesYCYicKboRwQ==",
 			"dev": true,
 			"requires": {
 				"@braintree/sanitize-url": "^3.1.0",
+				"crypto-random-string": "^3.0.1",
 				"d3": "^5.7.0",
-				"dagre-d3-renderer": "^0.5.8",
-				"dagre-layout": "^0.8.8",
-				"documentation": "^12.0.1",
-				"graphlibrary": "^2.2.0",
-				"gulp-print": "^5.0.2",
+				"dagre": "^0.8.4",
+				"dagre-d3": "^0.6.4",
+				"graphlib": "^2.1.7",
 				"he": "^1.2.0",
 				"lodash": "^4.17.11",
 				"minify": "^4.1.1",
@@ -5702,12 +3566,6 @@
 				"bn.js": "^4.0.0",
 				"brorand": "^1.0.1"
 			}
-		},
-		"mime": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-			"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
-			"dev": true
 		},
 		"mimic-fn": {
 			"version": "2.1.0",
@@ -5875,73 +3733,10 @@
 				}
 			}
 		},
-		"module-deps-sortable": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/module-deps-sortable/-/module-deps-sortable-5.0.0.tgz",
-			"integrity": "sha512-bnGGeghQmz/t/6771/KC4FmxpVm126iR6AAzzq4N6hVZQVl4+ZZBv+VF3PJmDyxXtVtgcgTSSP7NL+jq1QAHrg==",
-			"dev": true,
-			"requires": {
-				"JSONStream": "^1.0.3",
-				"browser-resolve": "^1.7.0",
-				"cached-path-relative": "^1.0.0",
-				"concat-stream": "~1.5.0",
-				"defined": "^1.0.0",
-				"detective": "^4.0.0",
-				"duplexer2": "^0.1.2",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.2",
-				"resolve": "^1.1.3",
-				"stream-combiner2": "^1.1.1",
-				"subarg": "^1.0.0",
-				"through2": "^2.0.0",
-				"xtend": "^4.0.0"
-			},
-			"dependencies": {
-				"concat-stream": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
-					"integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
-					"dev": true,
-					"requires": {
-						"inherits": "~2.0.1",
-						"readable-stream": "~2.0.0",
-						"typedarray": "~0.0.5"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.0.6",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-							"dev": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.1",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~1.0.6",
-								"string_decoder": "~0.10.x",
-								"util-deprecate": "~1.0.1"
-							}
-						}
-					}
-				},
-				"process-nextick-args": {
-					"version": "1.0.7",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-					"dev": true
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
-			}
-		},
 		"moment-mini": {
-			"version": "2.22.1",
-			"resolved": "https://registry.npmjs.org/moment-mini/-/moment-mini-2.22.1.tgz",
-			"integrity": "sha512-OUCkHOz7ehtNMYuZjNciXUfwTuz8vmF1MTbAy59ebf+ZBYZO5/tZKuChVWCX+uDo+4idJBpGltNfV8st+HwsGw==",
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/moment-mini/-/moment-mini-2.24.0.tgz",
+			"integrity": "sha512-9ARkWHBs+6YJIvrIp0Ik5tyTTtP9PoV0Ssu2Ocq5y9v8+NOOpWiRshAp8c4rZVWTOe+157on/5G+zj5pwIQFEQ==",
 			"dev": true
 		},
 		"move-concurrently": {
@@ -6060,27 +3855,6 @@
 				}
 			}
 		},
-		"node-releases": {
-			"version": "1.1.26",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-			"integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-			"dev": true,
-			"requires": {
-				"semver": "^5.3.0"
-			}
-		},
-		"normalize-package-data": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-			"dev": true,
-			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"resolve": "^1.10.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
-			}
-		},
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -6097,15 +3871,6 @@
 				"prepend-http": "^1.0.0",
 				"query-string": "^4.1.0",
 				"sort-keys": "^1.0.0"
-			}
-		},
-		"now-and-later": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
-			"integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
-			"dev": true,
-			"requires": {
-				"once": "^1.3.2"
 			}
 		},
 		"npm-run-path": {
@@ -6221,15 +3986,6 @@
 				"wrappy": "1"
 			}
 		},
-		"ordered-read-streams": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
-			"integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.1"
-			}
-		},
 		"os-browserify": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -6329,83 +4085,11 @@
 				"safe-buffer": "^5.1.1"
 			}
 		},
-		"parse-entities": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-			"integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-			"dev": true,
-			"requires": {
-				"character-entities": "^1.0.0",
-				"character-entities-legacy": "^1.0.0",
-				"character-reference-invalid": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-hexadecimal": "^1.0.0"
-			}
-		},
-		"parse-filepath": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
-			"integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
-			"dev": true,
-			"requires": {
-				"is-absolute": "^1.0.0",
-				"map-cache": "^0.2.0",
-				"path-root": "^0.1.1"
-			}
-		},
-		"parse-git-config": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-0.2.0.tgz",
-			"integrity": "sha1-Jygz/dFf6hRvt10zbSNrljtv9wY=",
-			"dev": true,
-			"requires": {
-				"ini": "^1.3.3"
-			}
-		},
-		"parse-json": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-			"dev": true,
-			"requires": {
-				"error-ex": "^1.3.1",
-				"json-parse-better-errors": "^1.0.1"
-			}
-		},
-		"parse-node-version": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
-			"integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
-			"dev": true
-		},
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
 			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
 			"dev": true
-		},
-		"parse-path": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/parse-path/-/parse-path-3.0.4.tgz",
-			"integrity": "sha512-wP70vtwv2DyrM2YoA7ZHVv4zIXa4P7dGgHlj+VwyXNDduLLVJ7NMY1zsFxjUUJ3DAwJLupGb1H5gMDDiNlJaxw==",
-			"dev": true,
-			"requires": {
-				"is-ssh": "^1.3.0",
-				"protocols": "^1.4.0"
-			}
-		},
-		"parse-url": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/parse-url/-/parse-url-3.0.2.tgz",
-			"integrity": "sha1-YCeHpwY6eV1yuGcxl1BecvYGEL4=",
-			"dev": true,
-			"requires": {
-				"is-ssh": "^1.3.0",
-				"normalize-url": "^1.9.1",
-				"parse-path": "^3.0.1",
-				"protocols": "^1.4.0"
-			}
 		},
 		"pascalcase": {
 			"version": "0.1.1",
@@ -6448,38 +4132,6 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
-		},
-		"path-root": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
-			"integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
-			"dev": true,
-			"requires": {
-				"path-root-regex": "^0.1.0"
-			}
-		},
-		"path-root-regex": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-			"integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
-			"dev": true
-		},
-		"path-type": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-			"dev": true,
-			"requires": {
-				"pify": "^3.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				}
-			}
 		},
 		"pbkdf2": {
 			"version": "3.0.17",
@@ -6622,12 +4274,6 @@
 				"clipboard": "^2.0.0"
 			}
 		},
-		"private": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-			"dev": true
-		},
 		"process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -6644,21 +4290,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
 			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
-			"dev": true
-		},
-		"property-information": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/property-information/-/property-information-4.2.0.tgz",
-			"integrity": "sha512-TlgDPagHh+eBKOnH2VYvk8qbwsCG/TAJdmTL7f1PROUcSO8qt/KSmShEQ/OKvock8X9tFjtqjCScyOkkkvIKVQ==",
-			"dev": true,
-			"requires": {
-				"xtend": "^4.0.1"
-			}
-		},
-		"protocols": {
-			"version": "1.4.7",
-			"resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
-			"integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
 			"dev": true
 		},
 		"prr": {
@@ -6720,12 +4351,6 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
-		"qs": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-			"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-			"dev": true
-		},
 		"query-string": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
@@ -6775,50 +4400,11 @@
 				"eve-raphael": "0.5.0"
 			}
 		},
-		"raw-body": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
-			"integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
-			"dev": true,
-			"requires": {
-				"bytes": "1",
-				"string_decoder": "0.10"
-			},
-			"dependencies": {
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
-			}
-		},
 		"raw-loader": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
 			"integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
 			"dev": true
-		},
-		"read-pkg": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-			"dev": true,
-			"requires": {
-				"load-json-file": "^4.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^3.0.0"
-			}
-		},
-		"read-pkg-up": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-			"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-			"dev": true,
-			"requires": {
-				"find-up": "^3.0.0",
-				"read-pkg": "^3.0.0"
-			}
 		},
 		"readable-stream": {
 			"version": "2.3.6",
@@ -6846,30 +4432,6 @@
 				"readable-stream": "^2.0.2"
 			}
 		},
-		"regenerate": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
-			"dev": true
-		},
-		"regenerate-unicode-properties": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
-			"integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
-			"dev": true,
-			"requires": {
-				"regenerate": "^1.4.0"
-			}
-		},
-		"regenerator-transform": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
-			"integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
-			"dev": true,
-			"requires": {
-				"private": "^0.1.6"
-			}
-		},
 		"regex-not": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -6880,190 +4442,11 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
-		"regexp-tree": {
-			"version": "0.1.11",
-			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.11.tgz",
-			"integrity": "sha512-7/l/DgapVVDzZobwMCCgMlqiqyLFJ0cduo/j+3BcDJIB+yJdsYCfKuI3l/04NV+H/rfNRdPIDbXNZHM9XvQatg==",
-			"dev": true
-		},
-		"regexpu-core": {
-			"version": "4.5.4",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-			"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
-			"dev": true,
-			"requires": {
-				"regenerate": "^1.4.0",
-				"regenerate-unicode-properties": "^8.0.2",
-				"regjsgen": "^0.5.0",
-				"regjsparser": "^0.6.0",
-				"unicode-match-property-ecmascript": "^1.0.4",
-				"unicode-match-property-value-ecmascript": "^1.1.0"
-			}
-		},
-		"regjsgen": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
-			"dev": true
-		},
-		"regjsparser": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-			"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
-			"dev": true,
-			"requires": {
-				"jsesc": "~0.5.0"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
-				}
-			}
-		},
 		"relateurl": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
 			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
 			"dev": true
-		},
-		"remark": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/remark/-/remark-9.0.0.tgz",
-			"integrity": "sha512-amw8rGdD5lHbMEakiEsllmkdBP+/KpjW/PRK6NSGPZKCQowh0BT4IWXDAkRMyG3SB9dKPXWMviFjNusXzXNn3A==",
-			"dev": true,
-			"requires": {
-				"remark-parse": "^5.0.0",
-				"remark-stringify": "^5.0.0",
-				"unified": "^6.0.0"
-			}
-		},
-		"remark-html": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/remark-html/-/remark-html-8.0.0.tgz",
-			"integrity": "sha512-3V2391GL3hxKhrkzYOyfPpxJ6taIKLCfuLVqumeWQOk3H9nTtSQ8St8kMYkBVIEAquXN1chT83qJ/2lAW+dpEg==",
-			"dev": true,
-			"requires": {
-				"hast-util-sanitize": "^1.0.0",
-				"hast-util-to-html": "^4.0.0",
-				"mdast-util-to-hast": "^3.0.0",
-				"xtend": "^4.0.1"
-			}
-		},
-		"remark-parse": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
-			"integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
-			"dev": true,
-			"requires": {
-				"collapse-white-space": "^1.0.2",
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-whitespace-character": "^1.0.0",
-				"is-word-character": "^1.0.0",
-				"markdown-escapes": "^1.0.0",
-				"parse-entities": "^1.1.0",
-				"repeat-string": "^1.5.4",
-				"state-toggle": "^1.0.0",
-				"trim": "0.0.1",
-				"trim-trailing-lines": "^1.0.0",
-				"unherit": "^1.0.4",
-				"unist-util-remove-position": "^1.0.0",
-				"vfile-location": "^2.0.0",
-				"xtend": "^4.0.1"
-			}
-		},
-		"remark-reference-links": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/remark-reference-links/-/remark-reference-links-4.0.4.tgz",
-			"integrity": "sha512-+2X8hwSQqxG4tvjYZNrTcEC+bXp8shQvwRGG6J/rnFTvBoU4G0BBviZoqKGZizLh/DG+0gSYhiDDWCqyxXW1iQ==",
-			"dev": true,
-			"requires": {
-				"unist-util-visit": "^1.0.0"
-			}
-		},
-		"remark-slug": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/remark-slug/-/remark-slug-5.1.2.tgz",
-			"integrity": "sha512-DWX+Kd9iKycqyD+/B+gEFO3jjnt7Yg1O05lygYSNTe5i5PIxxxPjp5qPBDxPIzp5wreF7+1ROCwRgjEcqmzr3A==",
-			"dev": true,
-			"requires": {
-				"github-slugger": "^1.0.0",
-				"mdast-util-to-string": "^1.0.0",
-				"unist-util-visit": "^1.0.0"
-			}
-		},
-		"remark-stringify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-5.0.0.tgz",
-			"integrity": "sha512-Ws5MdA69ftqQ/yhRF9XhVV29mhxbfGhbz0Rx5bQH+oJcNhhSM6nCu1EpLod+DjrFGrU0BMPs+czVmJZU7xiS7w==",
-			"dev": true,
-			"requires": {
-				"ccount": "^1.0.0",
-				"is-alphanumeric": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-whitespace-character": "^1.0.0",
-				"longest-streak": "^2.0.1",
-				"markdown-escapes": "^1.0.0",
-				"markdown-table": "^1.1.0",
-				"mdast-util-compact": "^1.0.0",
-				"parse-entities": "^1.0.2",
-				"repeat-string": "^1.5.4",
-				"state-toggle": "^1.0.0",
-				"stringify-entities": "^1.0.1",
-				"unherit": "^1.0.4",
-				"xtend": "^4.0.1"
-			}
-		},
-		"remark-toc": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/remark-toc/-/remark-toc-5.1.1.tgz",
-			"integrity": "sha512-vCPW4YOsm2CfyuScdktM9KDnJXVHJsd/ZeRtst+dnBU3B3KKvt8bc+bs5syJjyptAHfqo7H+5Uhz+2blWBfwow==",
-			"dev": true,
-			"requires": {
-				"mdast-util-toc": "^3.0.0",
-				"remark-slug": "^5.0.0"
-			}
-		},
-		"remote-origin-url": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.4.0.tgz",
-			"integrity": "sha1-TT4pAvNOLTfRwmPYdxC3frQIajA=",
-			"dev": true,
-			"requires": {
-				"parse-git-config": "^0.2.0"
-			}
-		},
-		"remove-bom-buffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
-			"integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
-			"dev": true,
-			"requires": {
-				"is-buffer": "^1.1.5",
-				"is-utf8": "^0.2.1"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-					"dev": true
-				}
-			}
-		},
-		"remove-bom-stream": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
-			"integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
-			"dev": true,
-			"requires": {
-				"remove-bom-buffer": "^3.0.0",
-				"safe-buffer": "^5.1.0",
-				"through2": "^2.0.3"
-			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
@@ -7081,12 +4464,6 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
-		},
-		"replace-ext": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
 			"dev": true
 		},
 		"require-directory": {
@@ -7148,15 +4525,6 @@
 			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
 			"dev": true
 		},
-		"resolve-options": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
-			"integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
-			"dev": true,
-			"requires": {
-				"value-or-function": "^3.0.0"
-			}
-		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -7207,12 +4575,6 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"safe-json-parse": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
-			"integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
 			"dev": true
 		},
 		"safe-regex": {
@@ -7347,9 +4709,9 @@
 			"dev": true
 		},
 		"slugify": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.4.tgz",
-			"integrity": "sha512-KP0ZYk5hJNBS8/eIjGkFDCzGQIoZ1mnfQRYS5WM3273z+fxGWXeN0fkwf2ebEweydv9tioZIHGZKoF21U07/nw==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.0.tgz",
+			"integrity": "sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ==",
 			"dev": true
 		},
 		"snapdragon": {
@@ -7538,44 +4900,6 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
 			"dev": true
 		},
-		"space-separated-tokens": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.4.tgz",
-			"integrity": "sha512-UyhMSmeIqZrQn2UdjYpxEkwY9JUrn8pP+7L4f91zRzOQuI8MF1FGLfYU9DKCYeLdo7LXMxwrX5zKFy7eeeVHuA==",
-			"dev": true
-		},
-		"spdx-correct": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
-			"dev": true,
-			"requires": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"spdx-exceptions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-			"dev": true
-		},
-		"spdx-expression-parse": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-			"dev": true,
-			"requires": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"spdx-license-ids": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
-			"dev": true
-		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -7600,12 +4924,6 @@
 				"figgy-pudding": "^3.5.1"
 			}
 		},
-		"state-toggle": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
-			"integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw==",
-			"dev": true
-		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -7627,44 +4945,6 @@
 				}
 			}
 		},
-		"stream-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/stream-array/-/stream-array-1.1.2.tgz",
-			"integrity": "sha1-nl9zRfITfDDuO0mLkRToC1K7frU=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "~2.1.0"
-			},
-			"dependencies": {
-				"process-nextick-args": {
-					"version": "1.0.7",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "2.1.5",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-					"integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
-					"dev": true,
-					"requires": {
-						"buffer-shims": "^1.0.0",
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~1.0.6",
-						"string_decoder": "~0.10.x",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
-			}
-		},
 		"stream-browserify": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -7672,16 +4952,6 @@
 			"dev": true,
 			"requires": {
 				"inherits": "~2.0.1",
-				"readable-stream": "^2.0.2"
-			}
-		},
-		"stream-combiner2": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
-			"integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
-			"dev": true,
-			"requires": {
-				"duplexer2": "~0.1.0",
 				"readable-stream": "^2.0.2"
 			}
 		},
@@ -7724,12 +4994,6 @@
 			"version": "git+ssh://git@github.com/hackmdio/string.js.git#a68176b3d84ce13e19002eb5d052d599873188b8",
 			"from": "git+ssh://git@github.com/hackmdio/string.js.git#a68176b3d"
 		},
-		"string-template": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
-			"integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
-			"dev": true
-		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -7749,18 +5013,6 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
-		"stringify-entities": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
-			"integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
-			"dev": true,
-			"requires": {
-				"character-entities-html4": "^1.0.0",
-				"character-entities-legacy": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-hexadecimal": "^1.0.0"
-			}
-		},
 		"strip-ansi": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -7769,12 +5021,6 @@
 			"requires": {
 				"ansi-regex": "^3.0.0"
 			}
-		},
-		"strip-bom": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-			"dev": true
 		},
 		"strip-css-comments": {
 			"version": "3.0.0",
@@ -7805,23 +5051,6 @@
 			"requires": {
 				"loader-utils": "^1.1.0",
 				"schema-utils": "^1.0.0"
-			}
-		},
-		"subarg": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
-			"integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.1.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
 			}
 		},
 		"supports-color": {
@@ -7884,12 +5113,6 @@
 				}
 			}
 		},
-		"through": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
-		},
 		"through2": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -7899,22 +5122,6 @@
 				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
 			}
-		},
-		"through2-filter": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
-			"integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
-			"dev": true,
-			"requires": {
-				"through2": "~2.0.0",
-				"xtend": "~4.0.0"
-			}
-		},
-		"time-stamp": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-			"dev": true
 		},
 		"timers-browserify": {
 			"version": "2.0.10",
@@ -7932,40 +5139,10 @@
 			"dev": true,
 			"optional": true
 		},
-		"tiny-lr": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
-			"integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
-			"dev": true,
-			"requires": {
-				"body": "^5.1.0",
-				"debug": "^3.1.0",
-				"faye-websocket": "~0.10.0",
-				"livereload-js": "^2.3.0",
-				"object-assign": "^4.1.0",
-				"qs": "^6.4.0"
-			}
-		},
-		"to-absolute-glob": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-			"integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
-			"dev": true,
-			"requires": {
-				"is-absolute": "^1.0.0",
-				"is-negated-glob": "^1.0.0"
-			}
-		},
 		"to-arraybuffer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
 			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
-			"dev": true
-		},
-		"to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
 			"dev": true
 		},
 		"to-object-path": {
@@ -8016,49 +5193,10 @@
 				"repeat-string": "^1.6.1"
 			}
 		},
-		"to-through": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
-			"integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
-			"dev": true,
-			"requires": {
-				"through2": "^2.0.3"
-			}
-		},
-		"trim": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
-			"dev": true
-		},
-		"trim-lines": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.2.tgz",
-			"integrity": "sha512-3GOuyNeTqk3FAqc3jOJtw7FTjYl94XBR5aD9QnDbK/T4CA9sW/J0l9RoaRPE9wyPP7NF331qnHnvJFBJ+IDkmQ==",
-			"dev": true
-		},
-		"trim-right": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-			"dev": true
-		},
-		"trim-trailing-lines": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
-			"integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==",
-			"dev": true
-		},
-		"trough": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
-			"integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==",
-			"dev": true
-		},
 		"try-catch": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/try-catch/-/try-catch-2.0.0.tgz",
-			"integrity": "sha512-RPXpVjsbtWgymwGq5F/OWDFsjEzdvzwHFaMjWWW6f/p6+uk/N7YSKJHQfIfGqITfj8qH4cBqCLMnhKZBaKk7Kg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/try-catch/-/try-catch-2.0.1.tgz",
+			"integrity": "sha512-LsOrmObN/2WdM+y2xG+t16vhYrQsnV8wftXIcIOWZhQcBJvKGYuamJGwnU98A7Jxs2oZNkJztXlphEOoA0DWqg==",
 			"dev": true
 		},
 		"try-to-catch": {
@@ -8173,6 +5311,12 @@
 			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
 			"dev": true
 		},
+		"type-fest": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"dev": true
+		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -8186,15 +5330,21 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-			"integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.1.tgz",
+			"integrity": "sha512-W7KxyzeaQmZvUFbGj4+YFshhVrMBGSg2IbcYAjGWGvx8DHvJMclbTDMpffdxFUGPBHjIytk7KJUR/KUXstUGDw==",
 			"dev": true,
 			"requires": {
-				"commander": "~2.20.0",
+				"commander": "~2.20.3",
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+					"dev": true
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8203,89 +5353,11 @@
 				}
 			}
 		},
-		"unc-path-regex": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-			"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-			"dev": true
-		},
 		"underscore": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
 			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
 			"dev": true
-		},
-		"unherit": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
-			"integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.1",
-				"xtend": "^4.0.1"
-			}
-		},
-		"unicode-canonical-property-names-ecmascript": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
-			"dev": true
-		},
-		"unicode-match-property-ecmascript": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-			"dev": true,
-			"requires": {
-				"unicode-canonical-property-names-ecmascript": "^1.0.4",
-				"unicode-property-aliases-ecmascript": "^1.0.4"
-			}
-		},
-		"unicode-match-property-value-ecmascript": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
-			"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
-			"dev": true
-		},
-		"unicode-property-aliases-ecmascript": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
-			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
-			"dev": true
-		},
-		"unified": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
-			"integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
-			"dev": true,
-			"requires": {
-				"bail": "^1.0.0",
-				"extend": "^3.0.0",
-				"is-plain-obj": "^1.1.0",
-				"trough": "^1.0.0",
-				"vfile": "^2.0.0",
-				"x-is-string": "^0.1.0"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-					"dev": true
-				},
-				"vfile": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-					"integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.4",
-						"replace-ext": "1.0.0",
-						"unist-util-stringify-position": "^1.0.0",
-						"vfile-message": "^1.0.0"
-					}
-				}
-			}
 		},
 		"union-value": {
 			"version": "1.0.1",
@@ -8321,76 +5393,6 @@
 			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4"
-			}
-		},
-		"unique-stream": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
-			"integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
-			"dev": true,
-			"requires": {
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"through2-filter": "^3.0.0"
-			}
-		},
-		"unist-builder": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.4.tgz",
-			"integrity": "sha512-v6xbUPP7ILrT15fHGrNyHc1Xda8H3xVhP7/HAIotHOhVPjH5dCXA097C3Rry1Q2O+HbOLCao4hfPB+EYEjHgVg==",
-			"dev": true,
-			"requires": {
-				"object-assign": "^4.1.0"
-			}
-		},
-		"unist-util-generated": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.4.tgz",
-			"integrity": "sha512-SA7Sys3h3X4AlVnxHdvN/qYdr4R38HzihoEVY2Q2BZu8NHWDnw5OGcC/tXWjQfd4iG+M6qRFNIRGqJmp2ez4Ww==",
-			"dev": true
-		},
-		"unist-util-is": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-			"integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
-			"dev": true
-		},
-		"unist-util-position": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.0.3.tgz",
-			"integrity": "sha512-28EpCBYFvnMeq9y/4w6pbnFmCUfzlsc41NJui5c51hOFjBA1fejcwc+5W4z2+0ECVbScG3dURS3JTVqwenzqZw==",
-			"dev": true
-		},
-		"unist-util-remove-position": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz",
-			"integrity": "sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==",
-			"dev": true,
-			"requires": {
-				"unist-util-visit": "^1.1.0"
-			}
-		},
-		"unist-util-stringify-position": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
-			"dev": true
-		},
-		"unist-util-visit": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-			"integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-			"dev": true,
-			"requires": {
-				"unist-util-visit-parents": "^2.0.0"
-			}
-		},
-		"unist-util-visit-parents": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-			"integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-			"dev": true,
-			"requires": {
-				"unist-util-is": "^3.0.0"
 			}
 		},
 		"unset-value": {
@@ -8513,211 +5515,6 @@
 			"integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
 			"dev": true
 		},
-		"validate-npm-package-license": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-			"dev": true,
-			"requires": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
-			}
-		},
-		"value-or-function": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
-			"integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
-			"dev": true
-		},
-		"vfile": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.1.tgz",
-			"integrity": "sha512-lRHFCuC4SQBFr7Uq91oJDJxlnftoTLQ7eKIpMdubhYcVMho4781a8MWXLy3qZrZ0/STD1kRiKc0cQOHm4OkPeA==",
-			"dev": true,
-			"requires": {
-				"@types/unist": "^2.0.0",
-				"is-buffer": "^2.0.0",
-				"replace-ext": "1.0.0",
-				"unist-util-stringify-position": "^2.0.0",
-				"vfile-message": "^2.0.0"
-			},
-			"dependencies": {
-				"unist-util-stringify-position": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.1.tgz",
-					"integrity": "sha512-Zqlf6+FRI39Bah8Q6ZnNGrEHUhwJOkHde2MHVk96lLyftfJJckaPslKgzhVcviXj8KcE9UJM9F+a4JEiBUTYgA==",
-					"dev": true,
-					"requires": {
-						"@types/unist": "^2.0.2"
-					}
-				},
-				"vfile-message": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.1.tgz",
-					"integrity": "sha512-KtasSV+uVU7RWhUn4Lw+wW1Zl/nW8JWx7JCPps10Y9JRRIDeDXf8wfBLoOSsJLyo27DqMyAi54C6Jf/d6Kr2Bw==",
-					"dev": true,
-					"requires": {
-						"@types/unist": "^2.0.2",
-						"unist-util-stringify-position": "^2.0.0"
-					}
-				}
-			}
-		},
-		"vfile-location": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.5.tgz",
-			"integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ==",
-			"dev": true
-		},
-		"vfile-message": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
-			"dev": true,
-			"requires": {
-				"unist-util-stringify-position": "^1.1.1"
-			}
-		},
-		"vfile-reporter": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-6.0.0.tgz",
-			"integrity": "sha512-8Is0XxFxWJUhPJdOg3CyZTqd3ICCWg6r304PuBl818ZG91h4FMS3Q+lrOPS+cs5/DZK3H0+AkJdH0J8JEwKtDA==",
-			"dev": true,
-			"requires": {
-				"repeat-string": "^1.5.0",
-				"string-width": "^4.0.0",
-				"supports-color": "^6.0.0",
-				"unist-util-stringify-position": "^2.0.0",
-				"vfile-sort": "^2.1.2",
-				"vfile-statistics": "^1.1.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
-					"integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^5.2.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				},
-				"unist-util-stringify-position": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.1.tgz",
-					"integrity": "sha512-Zqlf6+FRI39Bah8Q6ZnNGrEHUhwJOkHde2MHVk96lLyftfJJckaPslKgzhVcviXj8KcE9UJM9F+a4JEiBUTYgA==",
-					"dev": true,
-					"requires": {
-						"@types/unist": "^2.0.2"
-					}
-				}
-			}
-		},
-		"vfile-sort": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-2.2.1.tgz",
-			"integrity": "sha512-5dt7xEhC44h0uRQKhbM2JAe0z/naHphIZlMOygtMBM9Nn0pZdaX5fshhwWit9wvsuP8t/wp43nTDRRErO1WK8g==",
-			"dev": true
-		},
-		"vfile-statistics": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/vfile-statistics/-/vfile-statistics-1.1.3.tgz",
-			"integrity": "sha512-CstaK/ebTz1W3Qp41Bt9Lj/2DmumFsCwC2sKahDNSPh0mPh7/UyMLCoU8ZBX34CRU0d61B4W41yIFsV0NKMZeA==",
-			"dev": true
-		},
-		"vinyl": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-			"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
-			"dev": true,
-			"requires": {
-				"clone": "^2.1.1",
-				"clone-buffer": "^1.0.0",
-				"clone-stats": "^1.0.0",
-				"cloneable-readable": "^1.0.0",
-				"remove-trailing-separator": "^1.0.1",
-				"replace-ext": "^1.0.0"
-			}
-		},
-		"vinyl-fs": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
-			"integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
-			"dev": true,
-			"requires": {
-				"fs-mkdirp-stream": "^1.0.0",
-				"glob-stream": "^6.1.0",
-				"graceful-fs": "^4.0.0",
-				"is-valid-glob": "^1.0.0",
-				"lazystream": "^1.0.0",
-				"lead": "^1.0.0",
-				"object.assign": "^4.0.4",
-				"pumpify": "^1.3.5",
-				"readable-stream": "^2.3.3",
-				"remove-bom-buffer": "^3.0.0",
-				"remove-bom-stream": "^1.2.0",
-				"resolve-options": "^1.1.0",
-				"through2": "^2.0.0",
-				"to-through": "^2.0.0",
-				"value-or-function": "^3.0.0",
-				"vinyl": "^2.0.0",
-				"vinyl-sourcemap": "^1.1.0"
-			}
-		},
-		"vinyl-sourcemap": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
-			"integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
-			"dev": true,
-			"requires": {
-				"append-buffer": "^1.0.2",
-				"convert-source-map": "^1.5.0",
-				"graceful-fs": "^4.1.6",
-				"normalize-path": "^2.1.1",
-				"now-and-later": "^2.0.0",
-				"remove-bom-buffer": "^3.0.0",
-				"vinyl": "^2.0.0"
-			},
-			"dependencies": {
-				"normalize-path": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-					"dev": true,
-					"requires": {
-						"remove-trailing-separator": "^1.0.1"
-					}
-				}
-			}
-		},
 		"viz.js": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/viz.js/-/viz.js-2.1.2.tgz",
@@ -8738,16 +5535,6 @@
 			"requires": {
 				"http-proxy-agent": "^2.1.0",
 				"https-proxy-agent": "^2.2.1"
-			}
-		},
-		"vue-template-compiler": {
-			"version": "2.6.10",
-			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",
-			"integrity": "sha512-jVZkw4/I/HT5ZMvRnhv78okGusqe0+qH2A0Em0Cp8aq78+NK9TII263CDVz2QXZsIT+yyV/gZc/j/vlwa+Epyg==",
-			"dev": true,
-			"requires": {
-				"de-indent": "^1.0.2",
-				"he": "^1.1.0"
 			}
 		},
 		"watchpack": {
@@ -8917,23 +5704,6 @@
 				}
 			}
 		},
-		"websocket-driver": {
-			"version": "0.7.3",
-			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
-			"integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
-			"dev": true,
-			"requires": {
-				"http-parser-js": ">=0.4.0 <0.4.11",
-				"safe-buffer": ">=5.1.0",
-				"websocket-extensions": ">=0.1.1"
-			}
-		},
-		"websocket-extensions": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
-			"dev": true
-		},
 		"which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -9018,12 +5788,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
-		},
-		"x-is-string": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
 			"dev": true
 		},
 		"xtend": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"js-sequence-diagrams": "git+https://github.com/Moeditor/js-sequence-diagrams.git",
 		"katex": "^0.10.2",
 		"lodash": "^4.17.15",
-		"mermaid": "^8.2.3",
+		"mermaid": "^8.4.8",
 		"mini-css-extract-plugin": "^0.8.0",
 		"mocha": "^6.1.4",
 		"prismjs": "^1.17.1",


### PR DESCRIPTION
Fix issue #11 . Previous version of mermaid didn't support background highlight, and thus crush the sequence diagrams.